### PR TITLE
Update Beach Event.lua

### DIFF
--- a/Events/Beach Event.lua
+++ b/Events/Beach Event.lua
@@ -224,11 +224,34 @@ local function isHappyHour()
 end
 
 local function eatIcecream()
+    
+    local activityToCocktailMap = {
+        Dung = ID_COCKTAIL.A_Hole_in_One,
+        Strength = ID_COCKTAIL.Pink_fizz,
+        Construction = ID_COCKTAIL.Georges_Peach_Delight,
+        Hunter = ID_COCKTAIL.Ugly_Duckling,
+        Ranged = ID_COCKTAIL.Pink_fizz,
+        Cooking = ID_COCKTAIL.Purple_Lumbridge,
+        Farming = ID_COCKTAIL.Palmer_Farmer,
+        Fishing = ID_COCKTAIL.Fishermans_Friend
+    }
+    
+    local requiredCocktailId = activityToCocktailMap[ActivitySelected]
+    
+    if UseCocktail and requiredCocktailId and API.Buffbar_GetIDstatus(requiredCocktailId, false).found then
+        API.logInfo("Advanced cocktail is active, ignoring temperature.")
+        return
+    end
+    
     if not isHeatWave() then
         API.logDebug("Heatwave = false")
         if not isHappyHour() then
             API.logDebug("Happyhour = false")
             if getBeachTemperature() >= 294 then
+                if UseCocktail and requiredCocktailId and API.InvItemcount_1(requiredCocktailId) > 0 then
+                    API.logInfo("Overheating, but an advanced cocktail is available. Letting the activity function handle it.")
+                    return
+                end
                 if API.InvItemFound1(ITEM_IDS.ICECREAM) then
                     API.DoAction_Inventory1(ITEM_IDS.ICECREAM, 0, 1, API.OFF_ACT_GeneralInterface_route)
                     API.RandomSleep2(1200, 0, 200)

--- a/Events/Beach Event.lua
+++ b/Events/Beach Event.lua
@@ -227,11 +227,8 @@ local function eatIcecream()
     
     local activityToCocktailMap = {
         Dung = ID_COCKTAIL.A_Hole_in_One,
-        Strength = ID_COCKTAIL.Pink_fizz,
         Construction = ID_COCKTAIL.Georges_Peach_Delight,
         Hunter = ID_COCKTAIL.Ugly_Duckling,
-        Ranged = ID_COCKTAIL.Pink_fizz,
-        Cooking = ID_COCKTAIL.Purple_Lumbridge,
         Farming = ID_COCKTAIL.Palmer_Farmer,
         Fishing = ID_COCKTAIL.Fishermans_Friend
     }


### PR DESCRIPTION
Added a check in the eatIcecream function so if we have advanced cocktails we can use them to continue training even if we are max heat. 

If you would rather eat ice cream before using the advanced cocktail (so you are truly max heat before falling back to advanced cocktail buffs move it below the inventory check)